### PR TITLE
Fix private key path

### DIFF
--- a/analog/src/app/lib/github.service.ts
+++ b/analog/src/app/lib/github.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {App} from 'octokit';
 
-import GITHUB_KEY from '../../../.env.private-key-pkcs8.key?raw';
+import GITHUB_KEY from '../../../.env.private-key.pem?raw';
 
 import type {Discussion, DiscussionComment, DiscussionDetails} from './github-interfaces';
 


### PR DESCRIPTION
This updates the path used to import the private key to match the path used to store the private key in the instructions: `.env.private-key.pem`.